### PR TITLE
Added bin folder with executable, runs main command with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Deploy files to a server via SFTP. Built as an addition to [Vuepress](https://gi
 
 ## Usage
 ```js
-const deploy = require('fh-deploy').default
+const deploy = require('fh-deploy')
 
 // either:
 deploy({

--- a/bin/fh-deploy.js
+++ b/bin/fh-deploy.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+// Local version replace global one
+// taken from webpack: https://github.com/webpack/webpack/blob/master/bin/webpack.js#L10
+try {
+	const localDeploy = require.resolve(path.join(process.cwd(), "node_modules", "fh-deploy", "bin", "fh-deploy.js"));
+	if(__filename !== localWebpack) {
+		return require(localWebpack);
+	}
+} catch(e) {}
+
+// get deploy command
+const deploy = require('../')
+
+// run on default config
+deploy(path.resolve(path.join(process.cwd(), '.deployrc')))

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const colors = require('colors')
 const sftp = new Client()
 const deploy = require('./src/deploy').default
 
-module.exports.default = config => {
+module.exports = config => {
 
     // if config is a path, load the path
     if( typeof config == 'string' || config instanceof String ){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-deploy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Deploy files to a server via SFTP.",
   "main": "index.js",
+  "bin": "./bin/fh-deploy.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
@SaFrMo with this PR fh-deploy can be run with only the config file, like how webpack works. This would remove the need for the deploy.js file in vuepress, and the deploy command in package.json would become:

`{ "deploy": "fh-deploy" }`

I also changed the main index file to export the main function directly, so it can now be imported both of these ways:

```
import deploy from 'fh-deploy'
const deploy = require('fh-deploy')
```

thoughts?