### PR TITLE
Rename config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Deploy files to a server via SFTP. Built as an addition to [Vuepress](https://gi
 
 ## Usage
 ```js
-const deploy = require('fh-deploy').default
+const deploy = require('fh-deploy')
 
 // either:
 deploy({

--- a/bin/fh-deploy.js
+++ b/bin/fh-deploy.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+// Local version replace global one
+// taken from webpack: https://github.com/webpack/webpack/blob/master/bin/webpack.js#L10
+try {
+	const localDeploy = require.resolve(path.join(process.cwd(), "node_modules", "fh-deploy", "bin", "fh-deploy.js"));
+	if(__filename !== localWebpack) {
+		return require(localWebpack);
+	}
+} catch(e) {}
+
+// get deploy command
+const deploy = require('../')
+
+// run on default config
+deploy(path.resolve(path.join(process.cwd(), '.deployrc')))

--- a/bin/fh-deploy.js
+++ b/bin/fh-deploy.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const path = require("path");
+const fs = require('fs');
 
 // Local version replace global one
 // taken from webpack: https://github.com/webpack/webpack/blob/master/bin/webpack.js#L10
@@ -14,5 +15,10 @@ try {
 // get deploy command
 const deploy = require('../')
 
+// get config from .deploy.config.js, fallback to .deployrc.json
+const config = fs.existsSync(path.join(process.cwd(), '.deploy.config.js')) ?
+	path.join(process.cwd(), '.deploy.config.js') :
+	path.join(process.cwd(), '.deployrc.json')
+
 // run on default config
-deploy(path.resolve(path.join(process.cwd(), '.deployrc')))
+deploy(path.resolve(config))

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const colors = require('colors')
 const sftp = new Client()
 const deploy = require('./src/deploy').default
 
-module.exports.default = config => {
+module.exports = config => {
 
     // if config is a path, load the path
     if( typeof config == 'string' || config instanceof String ){

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = config => {
 
     // if config is a path, load the path
     if( typeof config == 'string' || config instanceof String ){
-        config = JSON.parse( fs.readFileSync(config) )
+        config = require(config)
     }
 
     if( config.target === undefined ){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-deploy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Deploy files to a server via SFTP.",
   "main": "index.js",
+  "bin": "./bin/fh-deploy.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This depends on #1 

Changed the naming of config file so it looks for either `.deploy.config.js` (like webpack) or `.deployrc.json` (like eslint)

I also changed the way index.js reads the config file, so it's not explicitly expecting json to parse. It will now try and require the provided path, meaning a js file that exports valid json, OR just any json file will work.

I like the option of being able to use a .js file because then there can be logic that build out the config. i.e. different environment variables have different deploy specs, or maybe I just want to base64 encode my ftp password in the file rather than saving it as cleatext.

@SaFrMo  thoughts?